### PR TITLE
Updated template loader name since it's deprecated on django 1.4

### DIFF
--- a/billy/commands/serve.py
+++ b/billy/commands/serve.py
@@ -12,8 +12,8 @@ class Serve(BaseCommand):
         settings.configure(DEBUG=True, TIME_ZONE='UTC', SITE_ID=1,
                            USE_I18N=False,
                            TEMPLATE_LOADERS=(
-       'django.template.loaders.filesystem.load_template_source',
-       'django.template.loaders.app_directories.load_template_source',
+       'django.template.loaders.filesystem.Loader',
+       'django.template.loaders.app_directories.Loader',
                            ),
                            ROOT_URLCONF='billy.web.urls',
                            INSTALLED_APPS=('django.contrib.humanize',


### PR DESCRIPTION
This was making the admin page not load on django 1.4 since it was removed.
