### PR TITLE
_id should not assume abbreviation is two characters long

### DIFF
--- a/billy/importers/utils.py
+++ b/billy/importers/utils.py
@@ -68,7 +68,7 @@ def insert_with_id(obj):
     cursor = collection.find({'_id': id_reg}).sort('_id', -1).limit(1)
 
     try:
-        new_id = int(cursor.next()['_id'][3:]) + 1
+        new_id = int(cursor.next()['_id'][len(abbr) + 1:]) + 1
     except StopIteration:
         new_id = 1
 


### PR DESCRIPTION
I wasn't able to import without this fix.
