### PR TITLE
Use 'abbreviation' in scraper classes, rather than LEVEL_FIELD

### DIFF
--- a/billy/scrape/__init__.py
+++ b/billy/scrape/__init__.py
@@ -48,7 +48,7 @@ class ScraperMeta(type):
     def __new__(meta, classname, bases, classdict):
         cls = type.__new__(meta, classname, bases, classdict)
 
-        abbr = getattr(cls, settings.LEVEL_FIELD, None)
+        abbr = getattr(cls, 'abbreviation', None)
         scraper_type = getattr(cls, 'scraper_type', None)
 
         if abbr and scraper_type:
@@ -198,7 +198,7 @@ class Scraper(scrapelib.Scraper):
         self.log('save %s %s', obj['_type'], unicode(obj))
 
         # copy over LEVEL_FIELD
-        obj[settings.LEVEL_FIELD] = getattr(self, settings.LEVEL_FIELD)
+        obj[settings.LEVEL_FIELD] = getattr(self, 'abbreviation')
 
         filename = obj.get_filename()
         self.output_names.add(filename)     # keep tally of all output names


### PR DESCRIPTION
In addition to Philadelphia, I need Washington, D.C. data. For my local government scrapers, I chose "jurisdiction" as the LEVEL_FIELD, whereas OpenStates appropriately chooses "state".

This small difference causes a problem, because when building the _scraper_registry, Billy won't pick up Washington, D.C., because its LEVEL_FIELD is different. I'm wondering whether all scraper classes should just have an "abbreviation" attribute, rather than a LEVEL_FIELD attribute.

If we were to go ahead with that, my Washington, D.C. objects will be saved with a different LEVEL_FIELD that OpenStates (given that the LEVEL_FIELD will still be used in every other case), but that's not a problem. I've tested this, and I can run DC scrapers after changing `state = 'dc'` to `abbreviation = 'dc'`
