### PR TITLE
Fix inactive legislator admin lookup

### DIFF
--- a/billy/web/admin/views/__init__.py
+++ b/billy/web/admin/views/__init__.py
@@ -707,7 +707,7 @@ def legislators(request, abbr):
              'chamber': chamber_type}), key=keyfunc)
 
     inactive_legs = db.legislators.find({settings.LEVEL_FIELD: abbr.lower(),
-                                         'active': False})
+                                         'active': {'$ne': True}})
     inactive_legs = sorted(inactive_legs, key=lambda x: x['last_name'])
 
     return render(request, 'billy/legislators.html', {


### PR DESCRIPTION
Non-legislators are typically inactive. They sometimes don't even have an "active" field set. This commit ensures that they nonetheless appear in the admin for editing.
