### PR TITLE
Only apply the metadata backwards-compability shim if necessary

### DIFF
--- a/billy/web/api/handlers.py
+++ b/billy/web/api/handlers.py
@@ -115,6 +115,7 @@ def _metadata_backwards_shim(metadata):
 
 class AllMetadataHandler(BillyHandler):
     def read(self, request):
+        use_shim = bool(request.GET.get('fields'))
         fields = _build_field_list(request, {'abbreviation': 1,
                                              'name': 1,
                                              'feature_flags': 1,
@@ -123,21 +124,29 @@ class AllMetadataHandler(BillyHandler):
                                             })
         for f in fields.copy():
             if '_chamber_' in f:
+                use_shim = True
                 fields['chambers'] = 1
         data = db.metadata.find(fields=fields).sort('name')
-        return [_metadata_backwards_shim(m) for m in data]
+        if use_shim:
+            return [_metadata_backwards_shim(m) for m in data]
+        else:
+            return data
 
 
 class MetadataHandler(BillyHandler):
     def read(self, request, abbr):
+        use_shim = bool(request.GET.get('fields'))
         field_list = _build_field_list(request)
         if field_list:
             for f in field_list.copy():
                 if '_chamber_' in f:
+                    use_shim = True
                     field_list['chambers'] = 1
-        return _metadata_backwards_shim(
-            db.metadata.find_one({'_id': abbr.lower()}, fields=field_list)
-        )
+        data = db.metadata.find_one({'_id': abbr.lower()}, fields=field_list)
+        if use_shim:
+            return _metadata_backwards_shim(data)
+        else:
+            return data
 
 
 class BillHandler(BillyHandler):


### PR DESCRIPTION
i.e. if the fields query string parameter is empty or missing, or if the fields query string parameter mentions fields requiring backwards-compatibility. If my query looks like `fields=chambers`, it means I just want `chambers`, not all the backwards-compatibility fields. This fix doesn't break backwards-compatibility, since no one (using old, deprecated code) would be setting `fields=chambers` in order to get things like `lower_chamber_name`, etc.
