### PR TITLE
Have setup.py match requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,17 +24,18 @@ billy-update = billy.bin.update:main
 billy-util = billy.bin.util:main
 """,
       install_requires=[
-          "Django>=1.4.2",
+          "Django>1.4,<1.5",
+          "django-pjax",
+          "https://bitbucket.org/jespern/django-piston/get/tip.tar.gz",
           "boto",
-          "django-piston",
           "icalendar",
           "lxml>=2.2",
           "name_tools>=0.1.2",
           "nose",
           "pymongo>=2.2",
           "scrapelib>=0.7.0",
-          "unicodecsv",
-          "validictory>=0.7.1",
+          "unicodecsv!=0.9.3",
+          "validictory",
           "pyelasticsearch",
       ]
 )


### PR DESCRIPTION
I've set `install_requires` to exactly what `requirements.txt` has. You can replace the `tar.gz` with just `django-piston` if you prefer - I'm just making these match so that I can install billy with pip and get the correct dependencies.
