### PR TITLE
Allow terms to contain duplicate sessions when checking sessions.

### DIFF
--- a/billy/scrape/__init__.py
+++ b/billy/scrape/__init__.py
@@ -174,7 +174,7 @@ class Scraper(scrapelib.Scraper):
         raise NoDataForPeriod(term)
 
     def save_object(self, obj):
-        self.log('save %s %s', obj['_type'], unicode(obj))
+        self.log('save %s %s', obj['_type'], unicode(obj).encode('utf-8'))
 
         # copy jurisdiction to LEVEL_FIELD
         obj[settings.LEVEL_FIELD] = getattr(self, 'jurisdiction')


### PR DESCRIPTION
This change eliminates duplicates in all_sessions_in_terms when checking sessions; this allows specifying metadata terms of the following form, where multiple terms share common sessions:

```
    terms=[
        dict(name='2012-2016', start_year=2012, end_year=2016, sessions=['2012', '2013']),
        dict(name='2010-2014', start_year=2010, end_year=2014, sessions=['2012', '2013']),
    ],
```

Without this modification, billy returns an error (redacted, with extra debug output shown):

```
DBG all_sessions_in_terms [2012, 2013, 2012, 2013]
DBG all_sessions_in_terms [2012, 2012, 2013]
DBG all_sessions_in_terms [2012, 2013]
11:59:54 CRITICAL billy: Error: no session_details for session(s): ['2012', '2013']
```
