### PR TITLE
add unmodeled requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scrapelib>=1.0
 unicodecsv!=0.9.3
 validictory
 pyelasticsearch
+requests

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ billy-util = billy.bin.util:main
           "unicodecsv!=0.9.3",
           "validictory",
           "pyelasticsearch",
+          "requests"
       ]
 )


### PR DESCRIPTION
Was setting up a new virtual env, didn't have requests, wasn't pulled down when I ran 

```
 pip install -r requirements.txt
```

So this should fix that...
